### PR TITLE
Child windows

### DIFF
--- a/druid-shell/src/platform/gtk/window.rs
+++ b/druid-shell/src/platform/gtk/window.rs
@@ -184,6 +184,11 @@ impl WindowBuilder {
         self.menu = Some(menu);
     }
 
+    // Used to set a parent window when creating child-windows
+    pub(crate) fn set_parent(&mut self, parent: WindowHandle) {
+        log::warn!("WindowBuilder::set_parent is currently unimplemented for gtk platforms.");
+    }
+
     pub fn build(self) -> Result<WindowHandle, ShellError> {
         let handler = self
             .handler

--- a/druid-shell/src/platform/mac/window.rs
+++ b/druid-shell/src/platform/mac/window.rs
@@ -204,6 +204,11 @@ impl WindowBuilder {
         self.menu = Some(menu);
     }
 
+    // Used to set a parent window when creating child-windows
+    pub(crate) fn set_parent(&mut self, parent: WindowHandle) {
+        log::warn!("WindowBuilder::set_parent is currently unimplemented for mac platforms.");
+    }
+
     pub fn build(self) -> Result<WindowHandle, Error> {
         assert_main_thread();
         unsafe {

--- a/druid-shell/src/platform/web/window.rs
+++ b/druid-shell/src/platform/web/window.rs
@@ -367,6 +367,11 @@ impl WindowBuilder {
         self.menu = Some(menu);
     }
 
+    // Used to set a parent window when creating child-windows
+    pub(crate) fn set_parent(&mut self, parent: WindowHandle) {
+        // ignore
+    }
+
     pub fn build(self) -> Result<WindowHandle, Error> {
         let window = web_sys::window().ok_or_else(|| Error::NoWindow)?;
         let canvas = window

--- a/druid-shell/src/platform/x11/window.rs
+++ b/druid-shell/src/platform/x11/window.rs
@@ -148,6 +148,11 @@ impl WindowBuilder {
         // TODO(x11/menus): implement WindowBuilder::set_menu (currently a no-op)
     }
 
+    // Used to set a parent window when creating child-windows
+    pub(crate) fn set_parent(&mut self, parent: WindowHandle) {
+        log::warn!("WindowBuilder::set_parent is currently unimplemented for X11 platforms.");
+    }
+
     /// Registers and returns all the atoms that the window will need.
     fn atoms(&self, window_id: u32) -> Result<WindowAtoms, Error> {
         let conn = self.app.connection();

--- a/druid-shell/src/window.rs
+++ b/druid-shell/src/window.rs
@@ -306,6 +306,10 @@ impl WindowHandle {
     pub fn get_scale(&self) -> Result<Scale, Error> {
         self.0.get_scale().map_err(Into::into)
     }
+
+    pub(crate) fn get_platform_handle(&self) -> platform::WindowHandle {
+        self.0.clone()
+    }
 }
 
 /// A builder type for creating new windows.
@@ -392,6 +396,12 @@ impl WindowBuilder {
     /// [`state`]: enum.WindowState.html
     pub fn set_window_state(&mut self, state: WindowState) {
         self.0.set_window_state(state);
+    }
+
+    /// Set a parent window, if set will create the new window
+    /// as a child.
+    pub fn set_parent(&mut self, parent: WindowHandle) {
+        self.0.set_parent(parent.get_platform_handle());
     }
 
     /// Attempt to construct the platform window.

--- a/druid/examples/sub_window.rs
+++ b/druid/examples/sub_window.rs
@@ -138,15 +138,11 @@ impl<T, W: Widget<T>> Controller<T, W> for TooltipController {
                     } else {
                         let req = SubWindowRequirement::new(
                             ctx.widget_id(),
-                            WindowConfig::default()
-                                .show_titlebar(false)
-                                .window_size(Size::new(100.0, 23.0))
-                                .set_level(WindowLevel::Tooltip)
-                                .set_position(
-                                    ctx.window().get_position()
-                                        + window_pos.to_vec2()
-                                        + cursor_size.to_vec2(),
-                                ),
+                            WindowConfig::tooltip(
+                                Size::new(100.0, 23.0),
+                            ctx.window().get_position()
+                            + window_pos.to_vec2()
+                            + cursor_size.to_vec2()),
                             false,
                             Label::<()>::new(self.tip.clone()),
                             (),

--- a/druid/src/app.rs
+++ b/druid/src/app.rs
@@ -43,6 +43,9 @@ pub struct WindowConfig {
     pub(crate) show_titlebar: Option<bool>,
     pub(crate) level: Option<WindowLevel>,
     pub(crate) state: Option<WindowState>,
+    //TODO: Maybe place this somewhere else
+    pub(crate) parent: Option<WindowId>,
+    pub(crate) handle: Option<WindowHandle>,
 }
 
 /// A description of a window to be instantiated.
@@ -203,7 +206,26 @@ impl Default for WindowConfig {
             resizable: None,
             show_titlebar: None,
             level: None,
-            state: None
+            state: None,
+            parent: None,
+            handle: None,
+        }
+    }
+}
+
+impl WindowConfig {
+    #[allow(dead_code)]
+    /// Creates a WindowCofig
+    /// with default values for a tooltip window.
+    pub fn tooltip(size: Size, position: Point) -> Self {
+        WindowConfig {
+            size: Some(size),
+            position: Some(position),
+            resizable: Some(false),
+            show_titlebar: Some(false),
+            level: Some(WindowLevel::Tooltip),
+            state: Some(WindowState::RESTORED),
+            ..Default::default()
         }
     }
 }

--- a/druid/src/contexts.rs
+++ b/druid/src/contexts.rs
@@ -423,7 +423,8 @@ impl EventCtx<'_, '_> {
 
     // TODO - dynamically check that the type of the pod we are registering this on is the same as the type of the
     // requirement. Needs type ids recorded. This goes wrong if you don't have a pod between you and a lens.
-    pub fn new_sub_window(&mut self, requirement: SubWindowRequirement) {
+    pub fn new_sub_window(&mut self, mut requirement: SubWindowRequirement) {
+        requirement.window_config.parent = Some(self.window_id());
         if let Some(id) = requirement.host_id {
             self.widget_state.add_sub_window_host(id);
         }


### PR DESCRIPTION
I implemented child windows on windows.
new_sub_window() will automaticly add the parent window.

On windows if the parent window is destroyed the child window gets destroyed automaticly aswell.

maybe you can test on mac, from what I got off the docs it should be WindowHandle.nsview.window().addChildWindow()
and see if it behaves the same way.

I also added a tooltip constructor for WindowConfig, as this might be something commonly used. But its subjective so feel free to remove it.
